### PR TITLE
fix missing "var" definition

### DIFF
--- a/src/local.js
+++ b/src/local.js
@@ -5,7 +5,7 @@ module.exports = function LocalNodeTokens() {
     winston.info('%s Running in local mode.', PACKAGE_NAME);
 
     var tokenString = process.env.OAUTH_ACCESS_TOKENS;
-        tokens = tokenString
+    var tokens = tokenString
                     .split(',')
                     .map(token => token.split(':'))
                     .reduce((acc, t) => {


### PR DESCRIPTION
for current Node (7.4.0) it needs to have "var", "const", or "let" before the definition of the tokens variable, in order to make it accessable from the anonymous "get" function in line 19.